### PR TITLE
Fix permission problem

### DIFF
--- a/bin/dev_init.sh
+++ b/bin/dev_init.sh
@@ -3,11 +3,17 @@
 cd "$(dirname ${BASH_SOURCE[0]})"
 cd ..
 
-rm -rf var/cache/*
-rm -rf web/bundles
-rm -rf web/css
-rm -rf web/js
+echo "Cleaning dependencies."
+docker-compose exec php bash -c "rm -rf var/cache/* web/bundles web/css web/js"
+
+echo "composer install"
 docker-compose exec php bash -c "cd /var/www && composer install"
+
+echo "npm install"
 docker-compose exec php bash -c "cd /var/www/app/Resources/node_tools && npm install"
+
+echo "assentic:dump"
 docker-compose exec php php ../bin/console assetic:dump
+
+echo "doctrine:schema:create"
 docker-compose exec php php ../bin/console doctrine:schema:create


### PR DESCRIPTION
This fixes the permission problems when the php container installs the dependencies as the root user and the "rm -rf" command to cleanup these dependencies runs as a standard user on the host machine.